### PR TITLE
feat: use commit SHA as default revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ jobs:
       - name: Build
         uses: diplodoc-platform/docs-build-action@v3
         with:
-          revision: "pr-${{ github.event.pull_request.number }}"
+          revision: "${{ github.event.pull_request.head.sha }}"
           src-root: "./docs"
 ```


### PR DESCRIPTION
## Summary
- Changed the default `revision` input from `"default_revision"` to `${{ github.event.pull_request.head.sha || github.sha }}`
- For PR builds, this uses the HEAD commit SHA of the pull request
- For other events (push, workflow_dispatch), falls back to `github.sha`
- Updated README to reflect the new default and removed explicit `revision` from the PR build example

## Motivation
Previously, the recommended pattern was `pr-${{ github.event.pull_request.number }}`, which meant every push to the same PR overwrote the same preview stand. With SHA-based revisions, each push generates a unique preview — so reviewers can see the exact state of the latest commit.
